### PR TITLE
refactor: remove symbol exclusion filtering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,13 +234,6 @@ files = [
     "*_test.py",
     "conftest.py"
 ]
-
-# Exclude symbols (functions/classes with wildcard support)
-symbols = [
-    "_private_*",    # Private functions
-    "setup_*",       # Setup functions
-    "Temporary*"     # Temporary classes
-]
 ```
 
 **Common file exclusion patterns:**
@@ -385,7 +378,7 @@ jobs:
 - **Drift Detection**: Criteria-based detection (see `src/prompts.py`)
 - **Multi-Module Check**: Check all modules with `--all` flag
 - **Custom Prompts**: Inject preferences into generation (see Configuration)
-- **Exclusion Rules**: Filter files and symbols via `.dokken.toml`
+- **Exclusion Rules**: Filter files via `.dokken.toml`
 - **Multi-Provider LLM**: Claude (Haiku), OpenAI (GPT-4o-mini), Google (Gemini Flash)
 - **Cost-Optimized**: Fast, budget-friendly models
 - **Human-in-the-Loop**: Interactive questionnaire for context AI can't infer

--- a/docs/future-improvements.md
+++ b/docs/future-improvements.md
@@ -536,14 +536,6 @@ def test_drift_check_never_crashes(code: str, doc: str) -> None:
     assert isinstance(result.drift_detected, bool)
     assert isinstance(result.rationale, str)
     assert len(result.rationale) > 0
-
-@given(st.lists(st.text(min_size=1), min_size=1))
-def test_filter_excluded_symbols_preserves_structure(symbols: list[str]) -> None:
-    """Symbol filtering should never corrupt valid Python syntax."""
-    code = "\n".join(f"def {symbol}(): pass" for symbol in symbols)
-    filtered = _filter_excluded_symbols(code, symbols[:1])
-    # Should still be valid Python
-    ast.parse(filtered)
 ```
 
 **Benefits:**

--- a/src/config/loader.py
+++ b/src/config/loader.py
@@ -33,7 +33,7 @@ def load_config(*, module_path: str) -> DokkenConfig:
         DokkenConfig with merged configuration from all sources.
     """
     config_data: ConfigDataDict = {
-        "exclusions": {"files": [], "symbols": []},
+        "exclusions": {"files": []},
         "custom_prompts": {
             "global_prompt": None,
             "module_readme": None,

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -6,15 +6,11 @@ from src.constants import DEFAULT_CACHE_FILE, DRIFT_CACHE_SIZE
 
 
 class ExclusionConfig(BaseModel):
-    """Configuration for excluding files and symbols from documentation."""
+    """Configuration for excluding files from documentation."""
 
     files: list[str] = Field(
         default_factory=list,
         description="List of file patterns to exclude (supports glob patterns)",
-    )
-    symbols: list[str] = Field(
-        default_factory=list,
-        description="List of symbol names to exclude (supports wildcards)",
     )
 
 

--- a/src/config/types.py
+++ b/src/config/types.py
@@ -7,7 +7,6 @@ class ExclusionsDict(TypedDict, total=False):
     """Structure of the exclusions section in .dokken.toml."""
 
     files: list[str]
-    symbols: list[str]
 
 
 class CustomPromptsDict(TypedDict, total=False):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,6 @@ def test_exclusion_config_defaults() -> None:
     config = ExclusionConfig()
 
     assert config.files == []
-    assert config.symbols == []
 
 
 def test_dokken_config_defaults() -> None:
@@ -21,7 +20,6 @@ def test_dokken_config_defaults() -> None:
 
     assert isinstance(config.exclusions, ExclusionConfig)
     assert config.exclusions.files == []
-    assert config.exclusions.symbols == []
     assert config.file_types == [".py"]
     assert config.file_depth is None
 
@@ -34,7 +32,6 @@ def test_load_config_no_config_file(tmp_path: Path) -> None:
     config = load_config(module_path=str(module_dir))
 
     assert config.exclusions.files == []
-    assert config.exclusions.symbols == []
 
 
 def test_load_config_module_level_config(tmp_path: Path) -> None:
@@ -45,14 +42,12 @@ def test_load_config_module_level_config(tmp_path: Path) -> None:
     config_content = """
 [exclusions]
 files = ["__init__.py", "*_test.py"]
-symbols = ["_private_*", "setup"]
 """
     (module_dir / ".dokken.toml").write_text(config_content)
 
     config = load_config(module_path=str(module_dir))
 
     assert config.exclusions.files == ["__init__.py", "*_test.py"]
-    assert config.exclusions.symbols == ["_private_*", "setup"]
 
 
 def test_load_config_repo_level_config(tmp_path: Path) -> None:
@@ -69,14 +64,12 @@ def test_load_config_repo_level_config(tmp_path: Path) -> None:
     repo_config = """
 [exclusions]
 files = ["conftest.py"]
-symbols = ["test_*"]
 """
     (repo_root / ".dokken.toml").write_text(repo_config)
 
     config = load_config(module_path=str(module_dir))
 
     assert config.exclusions.files == ["conftest.py"]
-    assert config.exclusions.symbols == ["test_*"]
 
 
 def test_load_config_merge_module_and_repo(tmp_path: Path) -> None:
@@ -93,7 +86,6 @@ def test_load_config_merge_module_and_repo(tmp_path: Path) -> None:
     repo_config = """
 [exclusions]
 files = ["conftest.py"]
-symbols = ["test_*"]
 """
     (repo_root / ".dokken.toml").write_text(repo_config)
 
@@ -101,7 +93,6 @@ symbols = ["test_*"]
     module_config = """
 [exclusions]
 files = ["__init__.py"]
-symbols = ["_private_*"]
 """
     (module_dir / ".dokken.toml").write_text(module_config)
 
@@ -109,7 +100,6 @@ symbols = ["_private_*"]
 
     # Both configs should be merged (no duplicates)
     assert set(config.exclusions.files) == {"conftest.py", "__init__.py"}
-    assert set(config.exclusions.symbols) == {"test_*", "_private_*"}
 
 
 def test_load_config_no_duplicates(tmp_path: Path) -> None:
@@ -125,14 +115,12 @@ def test_load_config_no_duplicates(tmp_path: Path) -> None:
     repo_config = """
 [exclusions]
 files = ["__init__.py", "conftest.py"]
-symbols = ["test_*"]
 """
     (repo_root / ".dokken.toml").write_text(repo_config)
 
     module_config = """
 [exclusions]
 files = ["__init__.py"]
-symbols = ["test_*", "_private_*"]
 """
     (module_dir / ".dokken.toml").write_text(module_config)
 
@@ -140,9 +128,7 @@ symbols = ["test_*", "_private_*"]
 
     # Check no duplicates
     assert config.exclusions.files.count("__init__.py") == 1
-    assert config.exclusions.symbols.count("test_*") == 1
     assert set(config.exclusions.files) == {"__init__.py", "conftest.py"}
-    assert set(config.exclusions.symbols) == {"test_*", "_private_*"}
 
 
 def test_load_config_empty_exclusions(tmp_path: Path) -> None:
@@ -158,7 +144,6 @@ def test_load_config_empty_exclusions(tmp_path: Path) -> None:
     config = load_config(module_path=str(module_dir))
 
     assert config.exclusions.files == []
-    assert config.exclusions.symbols == []
 
 
 def test_load_config_no_exclusions_section(tmp_path: Path) -> None:
@@ -177,7 +162,6 @@ key = "value"
 
     # Should use defaults
     assert config.exclusions.files == []
-    assert config.exclusions.symbols == []
 
 
 # --- Tests for CustomPrompts ---
@@ -308,7 +292,6 @@ def test_load_config_custom_prompts_and_exclusions(tmp_path: Path) -> None:
     config_content = """
 [exclusions]
 files = ["__init__.py"]
-symbols = ["test_*"]
 
 [custom_prompts]
 global_prompt = "Be concise."
@@ -320,7 +303,6 @@ module_readme = "Focus on patterns."
 
     # Check exclusions
     assert config.exclusions.files == ["__init__.py"]
-    assert config.exclusions.symbols == ["test_*"]
 
     # Check custom prompts
     assert config.custom_prompts.global_prompt == "Be concise."
@@ -537,7 +519,6 @@ file_types = [".js", ".ts"]
 
 [exclusions]
 files = ["*.test.js", "*.spec.ts"]
-symbols = ["test_*"]
 """
     (module_dir / ".dokken.toml").write_text(config_content)
 
@@ -548,7 +529,6 @@ symbols = ["test_*"]
 
     # Check exclusions
     assert config.exclusions.files == ["*.test.js", "*.spec.ts"]
-    assert config.exclusions.symbols == ["test_*"]
 
 
 # --- Tests for File Depth ---
@@ -669,7 +649,6 @@ file_types = [".js", ".ts"]
 
 [exclusions]
 files = ["*.test.js"]
-symbols = ["test_*"]
 """
     (module_dir / ".dokken.toml").write_text(config_content)
 
@@ -679,7 +658,6 @@ symbols = ["test_*"]
     assert config.file_depth == 2
     assert config.file_types == [".js", ".ts"]
     assert config.exclusions.files == ["*.test.js"]
-    assert config.exclusions.symbols == ["test_*"]
 
 
 def test_load_config_validates_suspicious_custom_prompts(


### PR DESCRIPTION
Remove Python-specific symbol (function/class) filtering functionality from
the codebase. This feature was complex, slow, and not widely useful.

Changes:
- Remove _filter_excluded_symbols, _find_excluded_symbols, and
  _remove_excluded_lines functions from code_analyzer.py
- Simplify _read_and_filter_file to just _read_file (no filtering)
- Remove 'symbols' field from ExclusionConfig model
- Remove symbol-related tests from test_code_analyzer.py and test_config.py
- Update documentation to remove symbol exclusion examples
- Remove ast import (no longer needed)

File exclusions remain fully functional. Users can still exclude files using
glob patterns in .dokken.toml [exclusions] section.