### PR TITLE
docs: update file references to match current project structure

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -79,12 +79,12 @@ Manually invoke a code review:
 # → Provides comprehensive analysis against checklist
 # → Returns structured feedback with 🔴🟡🟢✨ priorities
 
-/review src/llm.py
+/review src/llm/llm.py
 # → Focuses analysis on the single file
 # → Checks code quality, testing, documentation
 # → References line numbers for specific issues
 
-/review src/workflows.py src/llm.py
+/review src/workflows.py src/llm/llm.py
 # → Reviews multiple files
 # → Cross-checks for consistency and patterns
 # → Identifies duplication between files

--- a/.claude/code-review-agent.md
+++ b/.claude/code-review-agent.md
@@ -88,10 +88,10 @@ The code review agent evaluates changes against these fundamental principles:
 - `main.py` - CLI only, no business logic
 - `workflows.py` - High-level orchestration, delegates to specialized modules
 - `input/` - Input gathering (code_analyzer.py - pure functions, no LLM calls; human_in_the_loop.py - interactive questionnaires only)
-- `llm.py` - LLM operations only, uses prompts from `prompts.py`
-- `prompts.py` - Prompt templates as constants
+- `llm/llm.py` - LLM operations only, uses prompts from `llm/prompts.py`
+- `llm/prompts.py` - Prompt templates as constants
 - `output/formatters.py` - Pure data transformation, no I/O
-- `config.py` - Configuration loading only
+- `config/` - Configuration loading only
 
 ### 2. Code Quality
 
@@ -307,10 +307,10 @@ The `generate_documentation()` function contains inline prompt text:
 
     prompt = "Generate documentation for..."
 
-**Problem:** Prompts should be in `prompts.py` for easy iteration and clear git diffs.
+**Problem:** Prompts should be in `llm/prompts.py` for easy iteration and clear git diffs.
 
 **Fix:**
-1. Add constant to `prompts.py`: `DOCUMENTATION_GENERATION_PROMPT = "..."`
+1. Add constant to `llm/prompts.py`: `DOCUMENTATION_GENERATION_PROMPT = "..."`
 2. Import and use: `prompt = DOCUMENTATION_GENERATION_PROMPT`
 
 **Reference:** See `docs/style-guide.md` - Module Responsibilities
@@ -319,7 +319,7 @@ The `generate_documentation()` function contains inline prompt text:
 **Testability Issue:**
 
 ```markdown
-🔴 **Untestable Code** (`src/llm.py:123`)
+🔴 **Untestable Code** (`src/llm/llm.py:123`)
 
 Function `generate_docs()` directly instantiates `Gemini()` client:
 
@@ -344,7 +344,7 @@ Function `generate_docs()` directly instantiates `Gemini()` client:
 **DRY Violation:**
 
 ```markdown
-🟡 **Code Duplication** (`src/formatters.py:78-92`, `src/formatters.py:156-170`)
+🟡 **Code Duplication** (`src/output/formatters.py:78-92`, `src/output/formatters.py:156-170`)
 
 Similar markdown formatting logic appears in two functions. Consider extracting:
 

--- a/.claude/commands/review-branch.md
+++ b/.claude/commands/review-branch.md
@@ -46,5 +46,5 @@ You are an expert code reviewer for the Dokken project. Review the provided code
 ## Usage Examples
 
 - `/review-branch` - Review all pending changes on current branch
-- `/review-branch src/llm.py` - Review specific file(s)
-- `/review-branch src/workflows.py src/prompts.py` - Review multiple files
+- `/review-branch src/llm/llm.py` - Review specific file(s)
+- `/review-branch src/workflows.py src/llm/prompts.py` - Review multiple files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ These checks ensure code quality and will be automatically verified by pre-commi
 ## Key Design Patterns
 
 1. **Structured Output**: All LLM operations return validated Pydantic models
-1. **Prompt-as-Constants**: Prompts stored in `prompts.py` for easy experimentation
+1. **Prompt-as-Constants**: Prompts stored in `llm/prompts.py` for easy experimentation
 1. **Dependency Injection**: Functions receive dependencies as parameters
 1. **Pure Functions**: Most business logic is in pure, testable functions
 1. **Deterministic LLM**: Temperature=0.0 for reproducible documentation
@@ -50,5 +50,5 @@ Key design decisions to keep in mind:
 - **Module Structure**: See [docs/style-guide.md](docs/style-guide.md#module-responsibilities) for separation of concerns
 - **File Type Overrides**: Module-level `file_types` replace (not extend) repo-level settings in `.dokken.toml`
 - **Drift-Based Generation**: Only generates docs when drift detected or no doc exists
-- **Search-Optimized Docs**: Templates optimized for grep/search (see `src/output/formatters.py` and `src/prompts.py`)
+- **Search-Optimized Docs**: Templates optimized for grep/search (see `src/output/formatters.py` and `src/llm/prompts.py`)
 - **Testing**: Use function-based tests, mock external dependencies, use fixtures from `conftest.py`

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ dokken generate src/auth --depth 2         # Custom depth
 - Changed function signatures
 - Modified exports
 - Major architectural changes
-- See `DRIFT_CHECK_PROMPT` in `src/prompts.py` for full criteria
+- See `DRIFT_CHECK_PROMPT` in `src/llm/prompts.py` for full criteria
 
 **Documentation Types**: Dokken generates three types of documentation:
 
@@ -375,7 +375,7 @@ jobs:
 
 - **Three Documentation Types**: Module READMEs, project READMEs, and style guides
 - **Configurable Depth**: Control code analysis depth (0=root only, -1=infinite recursion)
-- **Drift Detection**: Criteria-based detection (see `src/prompts.py`)
+- **Drift Detection**: Criteria-based detection (see `src/llm/prompts.py`)
 - **Multi-Module Check**: Check all modules with `--all` flag
 - **Custom Prompts**: Inject preferences into generation (see Configuration)
 - **Exclusion Rules**: Filter files via `.dokken.toml`
@@ -407,13 +407,10 @@ uvx ty check                  # Type checking
 A: Run `uv sync --all-groups` to install dependencies
 
 **Q: Drift detection too sensitive**
-A: Adjust criteria in `DRIFT_CHECK_PROMPT` in `src/prompts.py`
+A: Adjust criteria in `DRIFT_CHECK_PROMPT` in `src/llm/prompts.py`
 
 **Q: How to skip questionnaire?**
 A: Press `ESC` on first question
-
-**Q: Change base branch for drift detection?**
-A: Set `GIT_BASE_BRANCH` in `src/git.py`
 
 **Q: Exclude test files from documentation?**
 A: Add pattern to `.dokken.toml`:

--- a/docs/future-improvements.md
+++ b/docs/future-improvements.md
@@ -19,9 +19,9 @@ ______________________________________________________________________
 
 **Current State:** Some constants scattered across modules:
 
-- `TEMPERATURE = 0.0` in `src/llm.py:22`
-- `depth` defaults in `src/doc_configs.py:80,106,130`
-- Section headers hardcoded in `src/formatters.py` (e.g., "## Main Entry Points")
+- `TEMPERATURE = 0.0` in `src/llm/llm.py:22`
+- `depth` defaults in `src/doctypes/configs.py:86,112,136`
+- Section headers hardcoded in `src/output/formatters.py` (e.g., "## Main Entry Points")
 
 **Recommendation:** Consider moving to `src/constants.py`:
 
@@ -124,9 +124,9 @@ def _initialize_documentation_workflow(
 
 ______________________________________________________________________
 
-### 2. Simplify Generic Types in `doc_configs.py`
+### 2. Simplify Generic Types in `doctypes/configs.py`
 
-**Current State:** `src/doc_configs.py:25-35` uses complex generics:
+**Current State:** `src/doctypes/configs.py:30-59` uses complex generics:
 
 ```python
 @dataclass
@@ -227,7 +227,7 @@ ______________________________________________________________________
 
 ### 4. Consider Plugin Architecture for Formatters
 
-**Current State:** Formatters hardcoded in `formatters.py` and `doc_configs.py`
+**Current State:** Formatters hardcoded in `output/formatters.py` and `doctypes/configs.py`
 
 **Recommendation:** Allow custom formatters via plugin system (future enhancement):
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -34,9 +34,10 @@ git commit -m "docs: update documentation"
 src/
 ├── main.py              # CLI entry points (Click) - thin UI layer
 ├── workflows.py         # High-level orchestration - business logic
-├── llm.py               # LLM client and operations - structured output
-├── prompts.py           # LLM prompt templates - constants for easy iteration
-├── config.py            # Configuration loading - .dokken.toml
+├── llm/                 # LLM operations
+│   ├── llm.py           # LLM client and operations - structured output
+│   └── prompts.py       # LLM prompt templates - constants for easy iteration
+├── config/              # Configuration loading - .dokken.toml
 ├── records.py           # Pydantic models - structured data validation
 ├── exceptions.py        # Custom exceptions
 ├── git.py               # Git operations - subprocess wrapper
@@ -72,16 +73,12 @@ src/
 - Configurable depth traversal (`depth` parameter)
 - Respects `.dokken.toml` exclusions
 
-**`llm.py` - LLM Operations**
+**`llm/` - LLM Operations**
 
-- LLM initialization and interaction
-- Uses prompts from `prompts.py`
+- `llm.py`: LLM initialization and interaction
+- `prompts.py`: All LLM prompts as module-level constants
+- Uses prompts from `llm/prompts.py`
 - Returns structured Pydantic objects (from `records.py`)
-
-**`prompts.py` - Prompt Templates**
-
-- All LLM prompts as module-level constants
-- Easy iteration without touching logic
 - Git diffs show prompt changes clearly
 - Example: `DRIFT_CHECK_PROMPT`, `MODULE_GENERATION_PROMPT`
 
@@ -97,7 +94,7 @@ src/
 - `merger.py`: Markdown parsing and incremental update application
 - All output generation and document manipulation
 
-**`config.py` - Configuration**
+**`config/` - Configuration**
 
 - Loads `.dokken.toml` exclusion rules
 - Repo-level and module-level configs
@@ -111,11 +108,10 @@ src/
 ## Dependency Flow
 
 ```
-main.py (CLI) → workflows.py (Orchestration) → input/, llm.py, output/
+main.py (CLI) → workflows.py (Orchestration) → input/, llm/, output/
                                                  ↓      ↓        ↓
-                                                 config.py   prompts.py  doctypes/
-                                                             records.py  records.py
-                                                             doctypes/
+                                                 config/    llm/prompts.py  doctypes/
+                                                             records.py
 ```
 
 ## Code Style
@@ -267,13 +263,13 @@ def test_cli_invalid_module() -> None:
 
 **Add new prompt:**
 
-1. Add constant to `prompts.py`
-1. Use it in `llm.py`
+1. Add constant to `llm/prompts.py`
+1. Use it in `llm/llm.py`
 
 **Add new LLM operation:**
 
-1. Add prompt to `prompts.py`
-1. Add function to `llm.py`
+1. Add prompt to `llm/prompts.py`
+1. Add function to `llm/llm.py`
 1. Use it in `workflows.py`
 
 **Add new output format:**
@@ -348,7 +344,7 @@ git commit -m "docs: add PDF guide"
 - ✅ `uv run ruff format && uv run ruff check`
 - ✅ `uvx ty check`
 
-See [docs/releasing-to-pypi.md](releasing-to-pypi.md) for release workflow.
+See [releasing-to-pypi.md](releasing-to-pypi.md) for release workflow.
 
 ## Testing
 
@@ -501,7 +497,7 @@ def test_writes_file(tmp_path: Path) -> None:
 **Drift-Based Generation:**
 
 - Only generates docs when drift detected or no doc exists (saves LLM calls)
-- Criteria in `DRIFT_CHECK_PROMPT` (`src/prompts.py:6`)
+- Criteria in `DRIFT_CHECK_PROMPT` (`src/llm/prompts.py`)
 
 **Human-in-the-Loop:**
 

--- a/src/README.md
+++ b/src/README.md
@@ -20,9 +20,10 @@ Dokken is an AI-powered documentation generation and drift detection tool design
 - **src/doctypes/**: Documentation type system
   - **types.py**: DocType enum definitions
   - **configs.py**: DocType configuration registry
-- **src/llm.py**: LLM client and operations
-- **src/config.py**: Configuration loading and management
-- **src/prompts.py**: LLM prompt templates
+- **src/llm/**: LLM operations
+  - **llm.py**: LLM client and operations
+  - **prompts.py**: LLM prompt templates
+- **src/config/**: Configuration loading and management
 - **src/records.py**: Pydantic models for structured data validation
 - **src/exceptions.py**: Custom exception definitions
 - **src/file_utils.py**: Path resolution and directory operations


### PR DESCRIPTION
Update all documentation to reflect recent file reorganizations:
- prompts.py → llm/prompts.py
- config.py → config/ (package)
- llm.py → llm/llm.py
- doc_configs.py → doctypes/configs.py
- formatters.py → output/formatters.py

Also remove outdated troubleshooting entry about GIT_BASE_BRANCH
in src/git.py (file no longer exists).

Updated files:
- CLAUDE.md
- README.md
- docs/style-guide.md
- docs/future-improvements.md
- src/README.md
- .claude/README.md
- .claude/code-review-agent.md
- .claude/commands/review-branch.md