### PR TITLE
docs: fix interactive questionnaire keyboard shortcuts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ dokken generate src/auth --depth 2         # Custom depth
 
 **Keyboard shortcuts:**
 
-- `ESC` - Skip question or entire questionnaire (if first question)
-- `Enter` twice - Submit answer (supports multiline)
+- `Ctrl+C` - Skip question or entire questionnaire (if first question)
+- `Meta+Enter` or `Esc+Enter` - Submit answer (supports multiline)
 - Leave blank - Skip if no relevant information
 
 ## Configuration
@@ -418,7 +418,7 @@ A: Run `uv sync --all-groups` to install dependencies
 A: Adjust criteria in `DRIFT_CHECK_PROMPT` in `src/llm/prompts.py`
 
 **Q: How to skip questionnaire?**
-A: Press `ESC` on first question
+A: Press `Ctrl+C` on first question
 
 **Q: Exclude test files from documentation?**
 A: Add pattern to `.dokken.toml`:


### PR DESCRIPTION
The README incorrectly documented the questionnaire keyboard shortcuts.
Updated to match the actual implementation in src/input/human_in_the_loop.py:

- Changed ESC to Ctrl+C for skipping questions
- Changed "Enter twice" to "Meta+Enter or Esc+Enter" for submitting answers
- Updated both the main questionnaire section and troubleshooting FAQ