### PR TITLE
feat: enable PyPI publishing workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -11,8 +11,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # Temporarily disabled - change to 'if: true' when ready to publish to PyPI
-    if: false
+    if: true
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6


### PR DESCRIPTION
Enable automated PyPI publishing when releases are created by release-please.
The workflow uses trusted publishing (OIDC) for secure authentication.