### PR TITLE
feat: configure PyPI workflow to use GitHub environment

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: pypi
     if: true
 
     steps:


### PR DESCRIPTION
Add environment: pypi to the publish job to use the configured
GitHub environment with its protection rules and secrets.

https://claude.ai/code/session_01PssxtLLeNnohbZzqgT36gS