### PR TITLE
fix: use GitHub App token in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,10 +13,17 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
Replace GITHUB_TOKEN with GitHub App token to allow CI workflows to
trigger on release PRs. This resolves the issue where release PRs had
no checks running due to GitHub's security restriction that prevents
workflows triggered by GITHUB_TOKEN from spawning additional workflows.

Requires APP_ID variable and APP_PRIVATE_KEY secret to be configured
in repository settings.