### PR TITLE
fix: remove environment from PyPI publish workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -11,7 +11,6 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: pypi
     if: true
 
     steps:


### PR DESCRIPTION
The workflow specified 'environment: pypi' but the PyPI trusted
publishing configuration has no environment name set (as documented
in docs/releasing-to-pypi.md). This mismatch caused authentication
failures during publishing.

Removed the environment field to match the documented setup where
the PyPI trusted publisher has a blank environment name.

https://claude.ai/code/session_01FSc4Qg6GZrDQjQ9F97E2Hd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified publishing workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->