### PR TITLE
feat: require 7-day release age before dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
     "timezone": "UTC",
     "prConcurrentLimit": 5,
     "prHourlyLimit": 0,
+    "minimumReleaseAge": "7 days",
     "automerge": true,
     "platformAutomerge": true,
     "packageRules": [
@@ -52,15 +53,9 @@
             "rangeStrategy": "bump",
         },
         {
-            "description": "Dev dependencies can be more aggressive",
+            "description": "Dev dependencies",
             "matchDepTypes": ["dev-dependencies"],
             "automerge": true,
-            "minimumReleaseAge": "0 days",
-        },
-        {
-            "description": "Production dependencies need a bit more stability",
-            "matchDepTypes": ["dependencies"],
-            "minimumReleaseAge": "3 days",
         },
         {
             "description": "Update GitHub Actions",
@@ -79,6 +74,7 @@
         "enabled": true,
         "labels": ["security"],
         "automerge": true,
+        "minimumReleaseAge": "0 days",
         "schedule": ["at any time"],
     },
     "lockFileMaintenance": {


### PR DESCRIPTION
Guards against supply chain attacks by ensuring packages have been
published for at least 7 days before Renovate raises a PR. Vulnerability
alerts bypass this delay so security fixes are still applied immediately.

https://claude.ai/code/session_012iFtGfReHL6Es5ygqqr9BU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management policies to enforce a 7-day minimum release age for standard updates, improving stability by allowing time for validation before adoption.
  * Security vulnerability alerts remain eligible for immediate updates, ensuring urgent security concerns are addressed without delay.
  * Streamlined configuration by consolidating update policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->