### PR TITLE
fix(deps): use rangeStrategy=pin to prevent lockfile artifact failures

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,7 +50,7 @@
             "description": "Python dependencies - use uv",
             "matchManagers": ["pep621"],
             "enabled": true,
-            "rangeStrategy": "bump",
+            "rangeStrategy": "pin",
         },
         {
             "description": "Dev dependencies",


### PR DESCRIPTION
When rangeStrategy=bump, Renovate raises the lower bound (e.g. >=0.7.7)
but uv resolves to the latest available version (e.g. 0.7.8), which may
not have passed the minimumReleaseAge threshold. Using pin instead makes
Renovate set exact constraints (==0.7.7) so uv locks to precisely that
version, keeping the lockfile in sync with the intended update.

https://claude.ai/code/session_01RUoWaGM6TByx8CPee8JMfL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python dependency management strategy to pin versions instead of bumping them, ensuring more consistent and predictable dependency handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mortenkrane/dokken/pull/212)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->